### PR TITLE
Spelling fixes for Zork Zero

### DIFF
--- a/castle.zil
+++ b/castle.zil
@@ -1937,7 +1937,7 @@ you plunge into the moat and are devoured by ravenous alligators.">)>
       (DESC "Bastion")
       (LDESC
 "This room occupies a taller tower rising from the corner of the keep.
-The slitted windows are wider here, presumably to accomodate the weaponry
+The slitted windows are wider here, presumably to accommodate the weaponry
 of the period. The stair winds up and down from here.")
       (UP TO PARAPET)
       (DOWN TO SOLAR)

--- a/highway.zil
+++ b/highway.zil
@@ -882,7 +882,7 @@ outta here!\" Guards surround you and escort you out." CR>
 			      <GOTO ,FISHING-VILLAGE>)
 			     (<DOABLE-REQUEST>
 			      <JIGS-UP
-"\"Done!\" You learn that hanging is as excrutiatingly painful as promised.">)
+"\"Done!\" You learn that hanging is as excruciatingly painful as promised.">)
 			     (<OR <UNDOABLE-REQUEST>
 				  <PROB 50>>
 			      <JIGS-UP
@@ -890,7 +890,7 @@ outta here!\" Guards surround you and escort you out." CR>
 indeed quite quick and painless.">)
 			     (T
 			      <JIGS-UP
-"\"Done!\" You learn that hanging is as excrutiatingly painful as promised.">)>)
+"\"Done!\" You learn that hanging is as excruciatingly painful as promised.">)>)
 		      (T
 		       <TELL "\"Shut up until your number is called!\"" CR>
 		       <STOP>)>)>>

--- a/hints.zil
+++ b/hints.zil
@@ -165,7 +165,7 @@ eye...end of eternity...\""
 		 "ANSWER \"THE LETTER Y\"">
 	<PLTABLE "magic glove"
 		 "Putting the glove on gives you additional
-sensory keeness and dexterity.">
+sensory keenness and dexterity.">
 	<PLTABLE "magic cloak"
 		 "Wear it."
 		 "You've been teleported to a strange new region. See the

--- a/jester.zil
+++ b/jester.zil
@@ -57,7 +57,7 @@ of fashion nowadays.\"" CR>
 		      (<FSET? ,GOGGLES ,WORNBIT>
 		       <TELL
 ,YOU-SEE " right through the jester's clothes as though they were
-transparent! Embarassed, you turn away. (But not before noticing that
+transparent! Embarrassed, you turn away. (But not before noticing that
 the jester has pink butterflies stitched onto his underwear.)" CR>)
 		      (T
 		       <TELL

--- a/library.zil
+++ b/library.zil
@@ -83,7 +83,7 @@ located in Thriff and Accardi.\""
 of such notable works as THE LIVES OF THE TWELVE FLATHEADS and MUMBERTHRAX:
 THE MAN BEHIND THE LEGEND.\""
 <> MINX
-"\"An irrestibly cuddly animal.\""
+"\"An irresistably cuddly animal.\""
 <> WINDCAT
 "\"The fleetest land animal.\""
  ENDLESS FIRE

--- a/library.zil
+++ b/library.zil
@@ -122,7 +122,7 @@ the source of the Frigid River. The article goes into construction techniques,
 the dam's appeal as a tourist attraction, and the financial impact of the
 dam's cost on the economy of the GUE."
  DIABLO MASSACRE
-"\"The Diablo Massacre occured at the Zorbel Pass in 666 GUE when the invading
+"\"The Diablo Massacre occurred at the Zorbel Pass in 666 GUE when the invading
 armies of King Duncanthrax met a native militia of trollish warriors. The
 invaders were outnumbered but well-armed; the natives were equipped only with
 wooden clubs and a large piece of very strong garlic. Military historians

--- a/library.zil
+++ b/library.zil
@@ -33,7 +33,7 @@ was formed at the behest of King Duncanthrax in 668 GUE. Headquartered in the
 'You name it, we do it!'\""
 ( GREAT UNDERGROUND) ( HIGHWAY TOLL)
 "\"The Great Underground Highway is a system of toll roads stretching
-thoughout both the eastland and westland provinces.\""
+throughout both the eastland and westland provinces.\""
 <> SQUID
 "\"A bottom-dwelling aquatic creature.\""
 <> HELLHOUND

--- a/library.zil
+++ b/library.zil
@@ -243,7 +243,7 @@ Breadbasket of Quendor. The capital of the province is Gurth City.\""
 is a popular vacation spot.\""
 <> ( FIELDS FROTZEN)
 "\"The Fields of Frotzen, fertile farmland in the heart of Gurth province,
-produces an annual bounty of grain and are freqently referred to as the
+produces an annual bounty of grain and are frequently referred to as the
 Breadbasket of Quendor.\""
 <> FESTERON
 "\"A small village in Antharia.\""

--- a/library.zil
+++ b/library.zil
@@ -529,7 +529,7 @@ assumed the throne in 881 GUE.\"" CR>)
 		<TELL ".\"" CR>)>>
 
 <OBJECT WIZARD-OF-FROBOZZ
-	(DESC "Wiazard of Frobozz")
+	(DESC "Wizard of Frobozz")
 	(SYNONYM WIZARD FROBOZZ)
 	(OWNER WIZARD-OF-FROBOZZ)
 	(ACTION WIZARD-OF-FROBOZZ-F)>

--- a/oracle.zil
+++ b/oracle.zil
@@ -163,7 +163,7 @@ its huge mouth hangs open in an expression of insatiable hunger; its four ">
 	 <COND (<VERB? EXAMINE>
 		<TELL "The semi-spherical depression is a few inches across.">
 		<COND (<IN? ,RUBY ,DEPRESSION>
-		       <TELL " A huge ruby rests in the depresssion.">)>
+		       <TELL " A huge ruby rests in the depression.">)>
 		<CRLF>)
 	       (<AND <VERB? TAKE>
 		     <PRSO? ,RUBY>

--- a/prologue.zil
+++ b/prologue.zil
@@ -318,7 +318,7 @@ and northeast.">)>>
 	 <COND (<EQUAL? .RARG ,M-LOOK>
 		<COND (<RUNNING? I-PROLOGUE>
 		       <TELL
-"You are assaulted by waves of greasy odors and buffetted by mobs of
+"You are assaulted by waves of greasy odors and buffeted by mobs of
 bustling cooks and servants">)
 		      (T
 		       <TELL


### PR DESCRIPTION
These are the spelling fixes for Zork Zero from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.

A few typos of the typos I reported back then have already been fixed in this version. That's a good thing!